### PR TITLE
Simplified InitialValues builder function usage

### DIFF
--- a/demo/src/main/java/ovh/plrapps/mapcompose/demo/viewmodels/SimpleDemoVM.kt
+++ b/demo/src/main/java/ovh/plrapps/mapcompose/demo/viewmodels/SimpleDemoVM.kt
@@ -16,13 +16,10 @@ class SimpleDemoVM(application: Application) : AndroidViewModel(application) {
     private val tileStreamProvider = makeTileStreamProvider(appContext)
 
     val state: MapState by mutableStateOf(
-        MapState(
-            4, 4096, 4096,
-            initialValues = initialValues {
-                scroll(0.5, 0.5)
-                scale(1.2f)
-            }
-        ).apply {
+        MapState(4, 4096, 4096) {
+            scroll(0.5, 0.5)
+            scale(1.2f)
+        }.apply {
             addLayer(tileStreamProvider)
             shouldLoopScale = true
             enableRotation()

--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/api/LayoutApi.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/api/LayoutApi.kt
@@ -14,7 +14,6 @@ import ovh.plrapps.mapcompose.ui.layout.Fill
 import ovh.plrapps.mapcompose.ui.layout.Fit
 import ovh.plrapps.mapcompose.ui.layout.Forced
 import ovh.plrapps.mapcompose.ui.layout.MinimumScaleMode
-import ovh.plrapps.mapcompose.ui.state.InitialValues
 import ovh.plrapps.mapcompose.ui.state.MapState
 import ovh.plrapps.mapcompose.ui.state.ZoomPanRotateState
 import ovh.plrapps.mapcompose.utils.AngleDegree
@@ -65,24 +64,6 @@ suspend fun MapState.setScroll(offset: Offset) {
         awaitLayout()
 
         setScroll(offset.x, offset.y)
-    }
-}
-
-/**
- * Set initial values (see [InitialValues]) at [MapState] construction. Example:
- * ```
- * MapState(
- *  4, 4096, 4096,
- *  initialValues = initialValues {
- *    scroll(0.5, 0.5)
- *    scale(1.2f)
- *  }
- * )
- * ```
- */
-fun initialValues(block: InitialValues.() -> Unit): InitialValues {
-    return InitialValues().apply {
-        block()
     }
 }
 

--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/state/MapState.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/state/MapState.kt
@@ -35,8 +35,9 @@ class MapState(
     fullHeight: Int,
     tileSize: Int = 256,
     workerCount: Int = Runtime.getRuntime().availableProcessors() - 1,
-    initialValues: InitialValues = InitialValues()
+    initialValuesBuilder: InitialValues.() -> Unit = {}
 ) : ZoomPanRotateStateListener {
+    internal val initialValues = InitialValues().apply(initialValuesBuilder)
     internal val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     internal val zoomPanRotateState = ZoomPanRotateState(
         fullWidth = fullWidth,

--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/state/MapState.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/state/MapState.kt
@@ -184,7 +184,7 @@ class MapState(
  * }
  * ```
  */
-class InitialValues {
+class InitialValues internal constructor() {
     internal var x = 0.0
     internal var y = 0.0
     internal var screenOffset: Offset = Offset.Zero


### PR DESCRIPTION
Instead of:
```Kotlin
MapState(
    4, 4096, 4096,
    initialValues = initialValues {
        scroll(0.5, 0.5)
        scale(1.2f)
    }
)
```
We can do:
```Kotlin
MapState(4, 4096, 4096) {
    scroll(0.5, 0.5)
    scale(1.2f)
}
```