### PR TITLE
Implemented visible area padding functionality

### DIFF
--- a/demo/src/main/java/ovh/plrapps/mapcompose/demo/ui/MapComposeDemoApp.kt
+++ b/demo/src/main/java/ovh/plrapps/mapcompose/demo/ui/MapComposeDemoApp.kt
@@ -49,6 +49,9 @@ fun MapComposeDemoApp() {
             composable(MainDestinations.HTTP_TILES_DEMO.name) {
                 HttpTilesDemo()
             }
+            composable(MainDestinations.VISIBLE_AREA_PADDING.name) {
+                VisibleAreaPaddingDemo()
+            }
         }
     }
 }

--- a/demo/src/main/java/ovh/plrapps/mapcompose/demo/ui/NavGraph.kt
+++ b/demo/src/main/java/ovh/plrapps/mapcompose/demo/ui/NavGraph.kt
@@ -13,4 +13,5 @@ enum class MainDestinations(val title: String) {
     CALLOUT_DEMO("Callout (tap markers)"),
     ANIMATION_DEMO("Animation demo"),
     HTTP_TILES_DEMO("Remote HTTP tiles"),
+    VISIBLE_AREA_PADDING("Visible area padding")
 }

--- a/demo/src/main/java/ovh/plrapps/mapcompose/demo/ui/screens/VisibleAreaPaddingDemo.kt
+++ b/demo/src/main/java/ovh/plrapps/mapcompose/demo/ui/screens/VisibleAreaPaddingDemo.kt
@@ -1,0 +1,137 @@
+package ovh.plrapps.mapcompose.demo.ui.screens
+
+import androidx.compose.animation.expandHorizontally
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkHorizontally
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Surface
+import androidx.compose.material.Switch
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import ovh.plrapps.mapcompose.api.addMarker
+import ovh.plrapps.mapcompose.api.scrollTo
+import ovh.plrapps.mapcompose.api.setVisibleAreaPadding
+import ovh.plrapps.mapcompose.demo.ui.widgets.Marker
+import ovh.plrapps.mapcompose.demo.viewmodels.VisibleAreaPaddingVM
+import ovh.plrapps.mapcompose.ui.MapUI
+
+@Composable
+fun VisibleAreaPaddingDemo(
+    modifier: Modifier = Modifier, viewModel: VisibleAreaPaddingVM = viewModel()
+) {
+    val obstructionSize = 100.dp
+    val obstructionColor = Color(0xA0000000)
+    var leftObstructionEnabled by remember { mutableStateOf(true) }
+    var rightObstructionEnabled by remember { mutableStateOf(false) }
+    var topObstructionEnabled by remember { mutableStateOf(false) }
+    var bottomObstructionEnabled by remember { mutableStateOf(false) }
+    Column {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Switch(leftObstructionEnabled, onCheckedChange = { leftObstructionEnabled = !leftObstructionEnabled })
+                Text("Left")
+            }
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Switch(rightObstructionEnabled, onCheckedChange = { rightObstructionEnabled = !rightObstructionEnabled })
+                Text("Right")
+            }
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Switch(topObstructionEnabled, onCheckedChange = { topObstructionEnabled = !topObstructionEnabled })
+                Text("Top")
+            }
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Switch(bottomObstructionEnabled, onCheckedChange = { bottomObstructionEnabled = !bottomObstructionEnabled })
+                Text("Bottom")
+            }
+        }
+        Box {
+            MapUI(
+                modifier,
+                state = viewModel.state
+            )
+            androidx.compose.animation.AnimatedVisibility(
+                visible = leftObstructionEnabled,
+                enter = expandHorizontally(),
+                exit = shrinkHorizontally(),
+                modifier = Modifier.align(Alignment.CenterStart)
+            ) {
+                Surface(
+                    color = obstructionColor,
+                    modifier = Modifier.fillMaxHeight().width(obstructionSize)
+                ) {}
+            }
+            androidx.compose.animation.AnimatedVisibility(
+                visible = rightObstructionEnabled,
+                enter = expandHorizontally(expandFrom = Alignment.Start),
+                exit = shrinkHorizontally(),
+                modifier = Modifier.align(Alignment.CenterEnd)
+            ) {
+                Surface(
+                    color = obstructionColor,
+                    modifier = Modifier.fillMaxHeight().width(obstructionSize)
+                ) {}
+            }
+            androidx.compose.animation.AnimatedVisibility(
+                visible = topObstructionEnabled,
+                enter = expandVertically(),
+                exit = shrinkVertically(),
+                modifier = Modifier.align(Alignment.TopCenter)
+            ) {
+                Surface(
+                    color = obstructionColor,
+                    modifier = Modifier.fillMaxWidth().height(obstructionSize)
+                ) {}
+            }
+            androidx.compose.animation.AnimatedVisibility(
+                visible = bottomObstructionEnabled,
+                enter = expandVertically(),
+                exit = shrinkVertically(),
+                modifier = Modifier.align(Alignment.BottomCenter)
+            ) {
+                Surface(
+                    color = obstructionColor,
+                    modifier = Modifier.fillMaxWidth().height(obstructionSize)
+                ) {}
+            }
+        }
+    }
+
+    viewModel.state.addMarker("m0", 0.2, 0.2) { Marker() }
+    viewModel.state.setVisibleAreaPadding(
+        left = if (leftObstructionEnabled) obstructionSize else 0.dp,
+        right = if (rightObstructionEnabled) obstructionSize else 0.dp,
+        top = if (topObstructionEnabled) obstructionSize else 0.dp,
+        bottom = if (bottomObstructionEnabled) obstructionSize else 0.dp
+    )
+    LaunchedEffect(leftObstructionEnabled, rightObstructionEnabled, topObstructionEnabled, bottomObstructionEnabled) {
+        viewModel.state.scrollTo(0.2, 0.2)
+    }
+}

--- a/demo/src/main/java/ovh/plrapps/mapcompose/demo/viewmodels/VisibleAreaPaddingVM.kt
+++ b/demo/src/main/java/ovh/plrapps/mapcompose/demo/viewmodels/VisibleAreaPaddingVM.kt
@@ -1,0 +1,25 @@
+package ovh.plrapps.mapcompose.demo.viewmodels
+
+import android.app.Application
+import android.content.Context
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.AndroidViewModel
+import ovh.plrapps.mapcompose.api.*
+import ovh.plrapps.mapcompose.demo.providers.makeTileStreamProvider
+import ovh.plrapps.mapcompose.ui.state.MapState
+
+class VisibleAreaPaddingVM(application: Application) : AndroidViewModel(application) {
+    private val appContext: Context by lazy {
+        getApplication<Application>().applicationContext
+    }
+    private val tileStreamProvider = makeTileStreamProvider(appContext)
+
+    val state: MapState by mutableStateOf(
+        MapState(4, 4096, 4096) {
+            scale(1.2f)
+        }.apply {
+            addLayer(tileStreamProvider)
+        }
+    )
+}

--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/state/ZoomPanRotateState.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/state/ZoomPanRotateState.kt
@@ -64,6 +64,11 @@ internal class ZoomPanRotateState(
 
     internal var layoutSize by mutableStateOf(IntSize(0, 0))
 
+    /**
+     * Offset of the conceptual center of the map when moving the camera to a position
+     */
+    internal var visibleAreaOffset by mutableStateOf(IntOffset(0, 0))
+
     private var minScale = 0f   // should only be changed through MinimumScaleMode
         set(value) {
             field = value


### PR DESCRIPTION
Implements #57 

I have also added a demo to the demo app. Here is a video of the feature in action:
https://streamable.com/wt02ek

I have chosen not to make it move the camera when you change the padding (as you suggested in the issue). I have realized this is something I wouldn't want for my use case - I don't want the map moving when you open a side menu, but do want it taken into account if the map goes to a marker when the menu is open - so if I added it, it would have to be an optional feature so I can turn it off. On the other hand, if someone wants to update the map position when they update the padding, it's one line of code on the app side anyway (as I did in the demo app).
