### PR TITLE
Fix scroll constraints when scrollOffsetRatio is used

### DIFF
--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/state/ZoomPanRotateState.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/state/ZoomPanRotateState.kt
@@ -516,12 +516,12 @@ internal class ZoomPanRotateState(
 
     private fun constrainScrollX(scrollX: Float): Float {
         val offset = scrollOffsetRatio.x * layoutSize.width
-        return scrollX.coerceIn(-offset, max(0f, fullWidth * scale - layoutSize.width + offset))
+        return scrollX.coerceIn(-offset, max(offset, fullWidth * scale - layoutSize.width + offset))
     }
 
     private fun constrainScrollY(scrollY: Float): Float {
         val offset = scrollOffsetRatio.y * layoutSize.height
-        return scrollY.coerceIn(-offset, max(0f, fullHeight * scale - layoutSize.height + offset))
+        return scrollY.coerceIn(-offset, max(offset, fullHeight * scale - layoutSize.height + offset))
     }
 
     internal fun constrainScale(scale: Float): Float {


### PR DESCRIPTION
This seems to fix the issue with scroll constraints when `scrollOffsetRatio` is used I described in the first item in #80.

Before the change (cannot move the map to the top of the layout):

https://user-images.githubusercontent.com/71890197/200042300-eae6c5fd-08d0-4d4e-93df-b0b282e16d34.mp4

With the change applied:

https://user-images.githubusercontent.com/71890197/200042318-0d50ecce-04f2-4b91-a352-df9b4e0dffa2.mp4