### PR TITLE
Added methods for easier construction of Paths

### DIFF
--- a/demo/src/main/java/ovh/plrapps/mapcompose/demo/viewmodels/PathsVM.kt
+++ b/demo/src/main/java/ovh/plrapps/mapcompose/demo/viewmodels/PathsVM.kt
@@ -53,13 +53,8 @@ class PathsVM(application: Application) : AndroidViewModel(application) {
                 "tracks/$trackName.txt"
             )?.bufferedReader()?.lineSequence()
                 ?: return@with
-            val builder = makePathDataBuilder()
-            for (line in lines) {
-                val values = line.split(',')
-                builder.addPoint(values[0].toDouble(), values[1].toDouble())
-            }
-            val pathData = builder.build() ?: return@with
-            addPath(trackName, pathData, color = color, width = 12.dp)
+            val points = lines.map { line -> line.split(",").map(String::toDouble).let { it[0] to it[1] } }.toList()
+            addPath(trackName, points, color = color, width = 12.dp)
         }
     }
 }

--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/api/PathApi.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/api/PathApi.kt
@@ -13,7 +13,7 @@ import ovh.plrapps.mapcompose.ui.state.MapState
  * * [width] = 8.dp
  * * [color] = Color(0xFF448AFF)
  * * [offset] = 0
- * * [count] = number of points added to build [pathData]
+ * * [count] = number of points added to built [pathData]
  *
  * @param id The unique identifier of the path
  * @param pathData
@@ -30,6 +30,33 @@ fun MapState.addPath(
     offset: Int? = null,
     count: Int? = null
 ) {
+    pathState.addPath(id, pathData, width, color, offset, count)
+}
+
+/**
+ * Adds a path, optionally setting some properties. The default values are:
+ * * [width] = 8.dp
+ * * [color] = Color(0xFF448AFF)
+ * * [offset] = 0
+ * * [count] = number of points added to built [pathData]
+ *
+ * @param id The unique identifier of the path
+ * @param points The points of the path
+ * @param width The width of the path, in [Dp]
+ * @param color The color of the path
+ * @param offset The number of points to skip from the beginning of the path
+ * @param count The number of points to draw after [offset]
+ */
+fun MapState.addPath(
+    id: String,
+    points: List<Pair<Double, Double>>,
+    width: Dp? = null,
+    color: Color? = null,
+    offset: Int? = null,
+    count: Int? = null
+) {
+    val pathData = makePathData(points)
+        ?: throw IllegalArgumentException("Could not create a path from the provided list of points")
     pathState.addPath(id, pathData, width, color, offset, count)
 }
 
@@ -81,4 +108,11 @@ fun MapState.hasPath(id: String): Boolean {
  */
 fun MapState.makePathDataBuilder(): PathDataBuilder {
     return PathDataBuilder(zoomPanRotateState.fullWidth, zoomPanRotateState.fullHeight)
+}
+
+/**
+ * Build a new instance of [PathData] from the provided list of points.
+ */
+fun MapState.makePathData(points: List<Pair<Double, Double>>): PathData? {
+    return makePathDataBuilder().addPoints(points).build()
 }

--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/api/PathApi.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/api/PathApi.kt
@@ -93,6 +93,13 @@ fun MapState.removePath(id: String) {
 }
 
 /**
+ * Removes all paths.
+ */
+fun MapState.removeAllPaths() {
+    pathState.removeAllPaths()
+}
+
+/**
  * Check whether a path was already added or not.
  *
  * @param id The id of the path

--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/paths/PathComposer.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/paths/PathComposer.kt
@@ -76,11 +76,18 @@ class PathDataBuilder internal constructor(
     /**
      * Add a point to the path. Values are relative coordinates (in range [0f..1f]).
      */
-    fun addPoint(x: Double, y: Double) {
-        points.add(
-            Offset((x * fullWidth).toFloat(), (y * fullHeight).toFloat())
-        )
+    fun addPoint(x: Double, y: Double) = apply {
+        points.add(createOffset(x, y))
     }
+
+    /**
+     * Add points to the path. Values are relative coordinates (in range [0f..1f]).
+     */
+    fun addPoints(points: List<Pair<Double, Double>>) = apply {
+        this.points += points.map { (x, y) -> createOffset(x, y) }
+    }
+
+    private fun createOffset(x: Double, y: Double) = Offset((x * fullWidth).toFloat(), (y * fullHeight).toFloat())
 
     fun build(): PathData? {
         /* If there is only one point, the path has no sense */

--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/state/PathState.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/state/PathState.kt
@@ -32,6 +32,10 @@ internal class PathState {
         return pathState.remove(id) != null
     }
 
+    fun removeAllPaths() {
+        pathState.clear()
+    }
+
     fun updatePath(
         id: String,
         pathData: PathData? = null,


### PR DESCRIPTION
If you already have a list of points it doesn't feel great to have to add them to `PathDataBuilder` one by one, so I added a `addPoints` method to add a list of points. Also made the methods chainable, and added a `makePathData()` method to completely avoid having to use `PathDataBuilder` manually for simple cases.