### PR TITLE
Add support for drawing a closed path (with fill color)

### DIFF
--- a/demo/src/main/java/ovh/plrapps/mapcompose/demo/viewmodels/PathsVM.kt
+++ b/demo/src/main/java/ovh/plrapps/mapcompose/demo/viewmodels/PathsVM.kt
@@ -90,7 +90,6 @@ class PathsVM(application: Application) : AndroidViewModel(application) {
                 addPoint(0.14, 0.15)
                 addPoint(0.14, 0.18)
                 addPoint(0.28, 0.10)
-                isClosePath = true
             }
         }
     }

--- a/demo/src/main/java/ovh/plrapps/mapcompose/demo/viewmodels/PathsVM.kt
+++ b/demo/src/main/java/ovh/plrapps/mapcompose/demo/viewmodels/PathsVM.kt
@@ -78,6 +78,21 @@ class PathsVM(application: Application) : AndroidViewModel(application) {
         addTrack("track1", Color(0xFF448AFF))
         addTrack("track2", Color(0xFFFFFF00))
         addTrack("track3", pattern = listOf(Dash(dpToPx(8f)), Gap(dpToPx(4f))))
+
+        // filled polygon
+        with(state) {
+            addPath(
+                id = "filled polygon",
+                color = Color.Green,
+                fillColor = Color.Green.copy(alpha = .6f),
+                clickable = true,
+            ) {
+                addPoint(0.14, 0.15)
+                addPoint(0.14, 0.18)
+                addPoint(0.28, 0.10)
+                isClosePath = true
+            }
+        }
     }
 
     /**

--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/api/PathApi.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/api/PathApi.kt
@@ -4,11 +4,11 @@ package ovh.plrapps.mapcompose.api
 
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
+import ovh.plrapps.mapcompose.ui.gestures.model.HitType
 import ovh.plrapps.mapcompose.ui.paths.PathData
 import ovh.plrapps.mapcompose.ui.paths.PathDataBuilder
 import ovh.plrapps.mapcompose.ui.paths.model.Cap
 import ovh.plrapps.mapcompose.ui.paths.model.PatternItem
-import ovh.plrapps.mapcompose.ui.gestures.model.HitType
 import ovh.plrapps.mapcompose.ui.state.MapState
 
 /**
@@ -18,6 +18,7 @@ import ovh.plrapps.mapcompose.ui.state.MapState
  * @param pathData Obtained from [PathDataBuilder.build]
  * @param width The width of the path, in [Dp]. Defaults to 4.dp
  * @param color The color of the path. Defaults to Color(0xFF448AFF)
+ * @param fillColor If the path is [PathData.isClosedPath] the path will be filled with this color.
  * @param offset The number of points to skip from the beginning of the path. Defaults to 0.
  * @param count The number of points to draw after [offset]. Defaults to the number of points added
  * to built [pathData].
@@ -37,6 +38,7 @@ fun MapState.addPath(
     pathData: PathData,
     width: Dp? = null,
     color: Color? = null,
+    fillColor: Color? = color,
     offset: Int? = null,
     count: Int? = null,
     cap: Cap = Cap.Round,
@@ -45,7 +47,7 @@ fun MapState.addPath(
     zIndex: Float = 0f,
     pattern: List<PatternItem>? = null
 ) {
-    pathState.addPath(id, pathData, width, color, offset, count, cap, simplify, clickable, zIndex, pattern)
+    pathState.addPath(id, pathData, width, color, fillColor, offset, count, cap, simplify, clickable, zIndex, pattern)
 }
 
 /**
@@ -75,6 +77,7 @@ fun MapState.addPath(
     id: String,
     width: Dp? = null,
     color: Color? = null,
+    fillColor: Color? = color,
     offset: Int? = null,
     count: Int? = null,
     cap: Cap = Cap.Round,
@@ -85,7 +88,7 @@ fun MapState.addPath(
     builder: (PathDataBuilder).() -> Unit
 ): PathData? {
     val pathData = makePathDataBuilder().apply { builder() }.build() ?: return null
-    pathState.addPath(id, pathData, width, color, offset, count, cap, simplify, clickable, zIndex, pattern)
+    pathState.addPath(id, pathData, width, color, fillColor, offset, count, cap, simplify, clickable, zIndex, pattern)
     return pathData
 }
 
@@ -114,6 +117,7 @@ fun MapState.updatePath(
     visible: Boolean? = null,
     width: Dp? = null,
     color: Color? = null,
+    fillColor: Color? = color,
     offset: Int? = null,
     count: Int? = null,
     cap: Cap? = null,
@@ -122,7 +126,7 @@ fun MapState.updatePath(
     zIndex: Float? = null,
     pattern: List<PatternItem>? = null
 ) {
-    pathState.updatePath(id, pathData, visible, width, color, offset, count, cap, simplify, clickable, zIndex, pattern)
+    pathState.updatePath(id, pathData, visible, width, color, fillColor, offset, count, cap, simplify, clickable, zIndex, pattern)
 }
 
 /**

--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/api/PathApi.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/api/PathApi.kt
@@ -18,7 +18,7 @@ import ovh.plrapps.mapcompose.ui.state.MapState
  * @param pathData Obtained from [PathDataBuilder.build]
  * @param width The width of the path, in [Dp]. Defaults to 4.dp
  * @param color The color of the path. Defaults to Color(0xFF448AFF)
- * @param fillColor If the path is [PathData.isClosedPath] the path will be filled with this color.
+ * @param fillColor If set - the path will be closed and the area drawn in this color.
  * @param offset The number of points to skip from the beginning of the path. Defaults to 0.
  * @param count The number of points to draw after [offset]. Defaults to the number of points added
  * to built [pathData].
@@ -38,7 +38,7 @@ fun MapState.addPath(
     pathData: PathData,
     width: Dp? = null,
     color: Color? = null,
-    fillColor: Color? = color,
+    fillColor: Color? = null,
     offset: Int? = null,
     count: Int? = null,
     cap: Cap = Cap.Round,
@@ -77,7 +77,7 @@ fun MapState.addPath(
     id: String,
     width: Dp? = null,
     color: Color? = null,
-    fillColor: Color? = color,
+    fillColor: Color? = null,
     offset: Int? = null,
     count: Int? = null,
     cap: Cap = Cap.Round,
@@ -117,7 +117,7 @@ fun MapState.updatePath(
     visible: Boolean? = null,
     width: Dp? = null,
     color: Color? = null,
-    fillColor: Color? = color,
+    fillColor: Color? = null,
     offset: Int? = null,
     count: Int? = null,
     cap: Cap? = null,

--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/api/PathApi.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/api/PathApi.kt
@@ -18,7 +18,7 @@ import ovh.plrapps.mapcompose.ui.state.MapState
  * @param pathData Obtained from [PathDataBuilder.build]
  * @param width The width of the path, in [Dp]. Defaults to 4.dp
  * @param color The color of the path. Defaults to Color(0xFF448AFF)
- * @param fillColor If set - the path will be closed and the area drawn in this color.
+ * @param fillColor If set - the path will be filled and the area drawn in this color.
  * @param offset The number of points to skip from the beginning of the path. Defaults to 0.
  * @param count The number of points to draw after [offset]. Defaults to the number of points added
  * to built [pathData].

--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/paths/PathComposer.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/paths/PathComposer.kt
@@ -107,7 +107,7 @@ internal fun PathCanvas(
     ) {
         Paint().apply {
             style = Paint.Style.FILL
-            this.color = drawablePathState.fillColor?.toArgb() ?: drawablePathState.color.toArgb()
+            this.color = drawablePathState.fillColor?.toArgb() ?: Color.Transparent.toArgb()
         }
     }
 

--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/paths/PathComposer.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/paths/PathComposer.kt
@@ -66,7 +66,6 @@ internal fun PathCanvas(
                 count = offsetAndCount.y,
                 simplify = drawablePathState.simplify,
                 scale = zoomPRState.scale,
-                shouldClosePath = drawablePathState.fillColor != null
             )
         }
         drawablePathState.lastRenderedPath = value
@@ -215,7 +214,7 @@ class PathDataBuilder internal constructor(
     }
 }
 
-internal fun generatePath(pathData: PathData, offset: Int, count: Int, simplify: Float, scale: Float, shouldClosePath: Boolean): Path {
+internal fun generatePath(pathData: PathData, offset: Int, count: Int, simplify: Float, scale: Float): Path {
     val p = Path()
     val epsilon = simplify / scale
     val subList = pathData.data.subList(offset, offset + count)
@@ -234,9 +233,6 @@ internal fun generatePath(pathData: PathData, offset: Int, count: Int, simplify:
         } else {
             p.lineTo(point.x, point.y)
         }
-    }
-    if (shouldClosePath) {
-        p.close()
     }
     return p
 }

--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/state/PathState.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/state/PathState.kt
@@ -47,6 +47,7 @@ internal class PathState(
         path: PathData,
         width: Dp?,
         color: Color?,
+        fillColor: Color?,
         offset: Int?,
         count: Int?,
         cap: Cap,
@@ -56,7 +57,7 @@ internal class PathState(
         pattern: List<PatternItem>?
     ) {
         if (hasPath(id)) return
-        pathState[id] = DrawablePathState(id, path, width, color, offset, count, cap, simplify, clickable, zIndex, pattern)
+        pathState[id] = DrawablePathState(id, path, width, color,fillColor, offset, count, cap, simplify, clickable, zIndex, pattern)
     }
 
     fun removePath(id: String): Boolean {
@@ -73,6 +74,7 @@ internal class PathState(
         visible: Boolean? = null,
         width: Dp? = null,
         color: Color? = null,
+        fillColor: Color? = color,
         offset: Int? = null,
         count: Int? = null,
         cap: Cap? = null,
@@ -87,6 +89,7 @@ internal class PathState(
             visible?.also { path.visible = it }
             width?.also { path.width = it }
             color?.also { path.color = it }
+            fillColor?.also { path.fillColor = it }
             cap?.also { path.cap = it }
             simplify?.also { path.simplify = it.coerceAtLeast(0f) }
             if (offset != null || count != null || pathData != null) {
@@ -212,6 +215,7 @@ internal class DrawablePathState(
     pathData: PathData,
     width: Dp?,
     color: Color?,
+    fillColor: Color?,
     offset: Int?,
     count: Int?,
     cap: Cap,
@@ -225,6 +229,7 @@ internal class DrawablePathState(
     var visible by mutableStateOf(true)
     var width: Dp by mutableStateOf(width ?: 4.dp)
     var color: Color by mutableStateOf(color ?: Color(0xFF448AFF))
+    var fillColor: Color by mutableStateOf(fillColor ?: Color(0xFF448AFF))
     var cap: Cap by mutableStateOf(cap)
     var isClickable: Boolean by mutableStateOf(clickable)
     var zIndex: Float by mutableFloatStateOf(zIndex)

--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/state/PathState.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/state/PathState.kt
@@ -74,7 +74,7 @@ internal class PathState(
         visible: Boolean? = null,
         width: Dp? = null,
         color: Color? = null,
-        fillColor: Color? = color,
+        fillColor: Color? = null,
         offset: Int? = null,
         count: Int? = null,
         cap: Cap? = null,
@@ -229,7 +229,7 @@ internal class DrawablePathState(
     var visible by mutableStateOf(true)
     var width: Dp by mutableStateOf(width ?: 4.dp)
     var color: Color by mutableStateOf(color ?: Color(0xFF448AFF))
-    var fillColor: Color by mutableStateOf(fillColor ?: Color(0xFF448AFF))
+    var fillColor: Color? by mutableStateOf(fillColor)
     var cap: Cap by mutableStateOf(cap)
     var isClickable: Boolean by mutableStateOf(clickable)
     var zIndex: Float by mutableFloatStateOf(zIndex)


### PR DESCRIPTION
I had the requirement to draw polygons.
In order to do that, I just had to adapt the `addPath` capability a bit to draw closed paths.
Maybe that is useful for other users as well.

If the path is closed it will use `fillColor` to draw the closed polygon.

<img src=https://github.com/p-lr/MapCompose/assets/141158723/a23d1823-c9c0-4844-8e88-d6bf947bfe24 width=300>
